### PR TITLE
Terminal experience: streaming RPC probes, live pickers, chainz shell, one style system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,6 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
- "colored",
  "console",
  "dialoguer",
  "dirs",
@@ -1375,15 +1374,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "console"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -190,7 +190,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ dependencies = [
  "alloy-rlp",
  "borsh",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -319,7 +319,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -501,7 +501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -543,7 +543,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",
@@ -685,7 +685,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -1283,8 +1283,10 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "console",
  "dialoguer",
  "dirs",
+ "indicatif",
  "keyring",
  "predicates",
  "rand 0.9.2",
@@ -1385,15 +1387,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1680,15 +1681,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -2508,6 +2508,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,7 +3222,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3225,7 +3244,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3389,7 +3408,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4123,31 +4142,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.116",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4439,7 +4438,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror",
  "utf-8",
 ]
 
@@ -4496,6 +4495,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -5089,7 +5094,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.18",
+ "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time"] }
 indicatif = "0.18"
-colored = "3"
 aes-gcm = "0.10"
 base64 = "0.22"
 keyring = { version = "3", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ alloy = { version = "1", default-features = false, features = [
     "signer-local",
 ] }
 anyhow = "1"
-dialoguer = { version = "0.11", features = ["fuzzy-select"] }
+console = "0.16"
+dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 dirs = "6"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
@@ -32,6 +33,7 @@ serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time"] }
+indicatif = "0.18"
 colored = "3"
 aes-gcm = "0.10"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ automatically; for zsh/starship, add e.g.:
 ```toml
 # starship.toml
 [env_var.CHAINZ_CHAIN]
-format = "(⛓ $env_value) "
+format = "\\(⛓ $env_value\\) "
 ```
 
 ### Managing Keys

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ chainz exec -- cast block-number
 # Check config and RPC health; switch dead RPCs to healthy ones
 chainz doctor --fix
 
-# Open a subshell with chain environment
-chainz exec ethereum -- bash
+# Open a subshell with chain environment (prompt shows the chain)
+chainz shell ethereum
 
 # Install shell completions (zsh example)
 chainz completions zsh > ~/.zfunc/_chainz
@@ -157,13 +157,17 @@ Override the key for a single command:
 > chainz exec ethereum -k deployer -- forge script Deploy
 ```
 
-Open a subshell with all chain variables in the environment:
+### Chain Shells
 
-```bash
-> chainz exec ethereum -- bash
-$ echo $ETH_RPC_URL
-https://rpc.com
-$ exit
+`chainz shell [chain]` opens your `$SHELL` with the chain's environment
+(`ETH_RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `VERIFIER_*`, `CHAINZ_CHAIN`) —
+private keys are never injected. Bash prompts get a `(⛓ ethereum)` prefix
+automatically; for zsh/starship, add e.g.:
+
+```toml
+# starship.toml
+[env_var.CHAINZ_CHAIN]
+format = "(⛓ $env_value) "
 ```
 
 ### Managing Keys
@@ -199,7 +203,9 @@ Added key 'ci-key'
 `chainz doctor` checks key storage, key references, and RPC connectivity for
 every chain (concurrently). With `--fix`, any dead selected RPC is switched to
 a healthy alternative from that chain's RPC list. Exits nonzero when failures
-are found, so it can gate scripts:
+are found, so it can gate scripts. Interactive RPC tests and `doctor` probes
+time out after 4 seconds per endpoint; results stream in live and pickers
+list healthy endpoints fastest-first:
 
 ```bash
 > chainz doctor --fix

--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ Override the key for a single command:
 
 `chainz shell [chain]` opens your `$SHELL` with the chain's environment
 (`ETH_RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `VERIFIER_*`, `CHAINZ_CHAIN`) —
-private keys are never injected. Bash prompts get a `(⛓ ethereum)` prefix
-automatically; for zsh/starship, add e.g.:
+private keys are never injected. Shells that honor an inherited `PS1` get
+a `(⛓ ethereum)` prefix, but interactive shells often reset `PS1` from rc
+files, so this isn't reliable everywhere. For a prompt that always works
+(zsh, starship, or a customized bash), key off `CHAINZ_CHAIN` instead, e.g.:
 
 ```toml
 # starship.toml

--- a/docs/superpowers/plans/2026-07-16-terminal-experience.md
+++ b/docs/superpowers/plans/2026-07-16-terminal-experience.md
@@ -1,0 +1,899 @@
+# Terminal Experience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make chainz's CLI fast and coherent: one style system, streaming RPC checks with a 4s deadline, download progress, and a first-class `chainz shell`.
+
+**Architecture:** A new `src/ui.rs` module becomes the single output vocabulary (built on `console`, replacing `colored`). RPC probing in `chain/rpc.rs` becomes an event stream (`probe_urls` → mpsc receiver) consumed by live renderers in the wizard and doctor. Chainlist downloads stream with an indicatif progress bar. `chainz shell` reuses exec's chain resolution and env machinery.
+
+**Tech Stack:** Rust (edition 2024), console 0.16, indicatif 0.18, tokio mpsc, dialoguer (unchanged), assert_cmd tests.
+
+## Global Constraints
+
+- `--json` output and non-TTY output must remain byte-identical to today (integration tests pin much of it; do not break them).
+- No new prompt library; dialoguer stays (bumped 0.11 → 0.12 for console 0.16 alignment).
+- **Raw-vs-expanded rule:** config storage and on-screen display always use raw URLs (with `${VAR}` intact); `expand_rpc_url` output exists only inside probe calls and exec-time resolution. Never store or print an expanded URL.
+- Lazy-key rule: no command may touch key backends unless `@key`/`@wallet` is referenced (shell must not).
+- All commits go through `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test` green.
+- RPC probe deadline: exactly 4 seconds (`CHECK_DEADLINE`), replacing the 10s worst case in wizard/doctor paths.
+- GPG signing can time out: on `gpg: signing failed: Timeout`, wait ~8s and retry the commit once; if it fails again, leave changes staged and note it.
+
+---
+
+### Task 1: `ui` module and style dependencies
+
+**Files:**
+- Modify: `Cargo.toml` (add console, indicatif under `[dependencies]`)
+- Create: `src/ui.rs`
+- Modify: `src/lib.rs` (add `pub mod ui;`)
+
+**Interfaces:**
+- Produces: `ui::header(&str) -> String`, `ui::success(&str) -> String`, `ui::warn(&str) -> String`, `ui::fail(&str) -> String`, `ui::item(&str) -> String`, `ui::dim(&str) -> String`, `ui::emph(&str) -> String`. All return plain `String`s (styled only when stdout is a TTY — `console` handles detection).
+
+- [ ] **Step 1: Add dependencies**
+
+In `Cargo.toml` `[dependencies]` (keep alphabetical-ish placement near clap), and bump dialoguer so the whole stack shares console 0.16:
+
+```toml
+console = "0.16"
+indicatif = "0.18"
+dialoguer = { version = "0.12", features = ["fuzzy-select"] }
+```
+
+Run `cargo tree -d 2>/dev/null | grep -A2 console` — expected: no duplicate console versions. Fix any trivial dialoguer 0.11→0.12 API breaks surfaced by `cargo check` (the Select/FuzzySelect/Input/Confirm builder APIs are stable across this bump; if a method was renamed, follow the compiler suggestion).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/ui.rs` with only the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helpers_contain_glyph_and_message() {
+        assert!(success("done").contains("✓"));
+        assert!(success("done").contains("done"));
+        assert!(warn("careful").contains("⚠"));
+        assert!(fail("broken").contains("✗"));
+        assert!(item("step").contains("▸"));
+        assert!(header("Section").contains("Section"));
+        assert!(header("Section").contains("═"));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test ui:: 2>&1 | tail -5`
+Expected: compile error — `success` etc. not found.
+
+- [ ] **Step 4: Implement the module**
+
+Prepend to `src/ui.rs`:
+
+```rust
+//! The single output vocabulary for chainz. Every user-facing styled line
+//! goes through these helpers so glyphs and palette stay coherent.
+//! `console` styles only when stderr/stdout is a TTY and honors NO_COLOR.
+
+use console::style;
+
+pub fn header(title: &str) -> String {
+    format!(
+        "\n{}\n{}",
+        style(title).cyan().bold(),
+        style("═".repeat(50)).dim()
+    )
+}
+
+pub fn success(msg: &str) -> String {
+    format!("{} {}", style("✓").green(), msg)
+}
+
+pub fn warn(msg: &str) -> String {
+    format!("{} {}", style("⚠").yellow(), msg)
+}
+
+pub fn fail(msg: &str) -> String {
+    format!("{} {}", style("✗").red(), msg)
+}
+
+pub fn item(msg: &str) -> String {
+    format!("{} {}", style("▸").cyan(), msg)
+}
+
+pub fn dim(msg: &str) -> String {
+    style(msg).dim().to_string()
+}
+
+pub fn emph(msg: &str) -> String {
+    style(msg).yellow().to_string()
+}
+```
+
+Add `pub mod ui;` to `src/lib.rs` (alphabetical: after `pub mod opt;`... keep the existing sorted order — insert between `pub mod opt;` and `pub mod variables;`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test ui:: 2>&1 | tail -3`
+Expected: `helpers_contain_glyph_and_message ... ok`
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt && git add -A && git commit -m "feat: add ui module (console/indicatif style stack)"
+```
+
+---
+
+### Task 2: Migrate all output to `ui`, drop `colored`
+
+**Files:**
+- Modify: `src/chain/mod.rs` (both `Display` impls)
+- Modify: `src/chain/wizard.rs` (headers, ✓/✗ lines)
+- Modify: `src/doctor.rs` (all styled lines)
+- Modify: `src/init.rs` (banner)
+- Modify: `Cargo.toml` (remove `colored`)
+
+**Interfaces:**
+- Consumes: every `ui::` helper from Task 1.
+- Produces: no new interfaces; zero remaining `colored` usage (`grep -rn "colored" src/` returns nothing).
+
+- [ ] **Step 1: Migrate `src/chain/mod.rs`**
+
+Replace `use colored::*;` with `use crate::ui;` and `use console::style;`. In `Display for ChainDefinition`, the pattern for each line becomes (example for the name line; apply the same mechanical substitution to every line — `bright_blue()` → `style(..).cyan()`, `yellow()` → `ui::emph(..)`, `bright_green()` → `style(..).green()`, `bright_red()` → `style(..).red()`, `bright_black()` → `style(..).dim()`):
+
+```rust
+writeln!(
+    f,
+    "{}: {}{}",
+    style("Chain").cyan().bold(),
+    ui::emph(&self.name),
+    if self.aliases.is_empty() {
+        String::new()
+    } else {
+        ui::dim(&format!(" ({})", self.aliases.join(", ")))
+    }
+)?;
+```
+
+- [ ] **Step 2: Migrate `src/chain/wizard.rs`**
+
+Replace section banners:
+
+```rust
+// before
+println!("\n{}", "Chain Selection".bright_blue().bold());
+println!("{}", "═".bright_black().repeat(50));
+// after
+println!("{}", crate::ui::header("Chain Selection"));
+```
+
+Replace status lines: `format!("{} {}", "✓".bright_green(), ...)` → `crate::ui::success(&format!("{}", ...))`, same for ✗ → `ui::fail`, ⋯ pending lines → `ui::dim(&format!("⋯ {}", ...))`. Remove `use colored::*;`.
+
+- [ ] **Step 3: Migrate `src/doctor.rs` and `src/init.rs` the same way**
+
+Every `"✓".bright_green()` composite becomes `ui::success(...)`, `"✗".bright_red()` → `ui::fail(...)`, `"⚠".bright_yellow()` → `ui::warn(...)`, section titles → `ui::header(...)`.
+
+- [ ] **Step 4: Remove colored**
+
+Delete the `colored = "3"` line from `Cargo.toml`. Run `grep -rn "colored" src/` — expected: no output.
+
+- [ ] **Step 5: Full verify (output contracts)**
+
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test 2>&1 | grep 'test result'`
+Expected: all suites pass — the integration tests pin non-TTY output (plain text), which `console` produces identically.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "refactor: route all styled output through ui, drop colored"
+```
+
+---
+
+### Task 3: Streaming RPC probes with 4s deadline; collapse the old RPC surface
+
+**Files:**
+- Modify: `src/chain/rpc.rs` (new stream API; delete `Rpc` plumbing)
+- Modify: `src/chain/mod.rs` (delete `Rpc` struct + its `Display`; update `pub use`)
+- Test: unit tests in `src/chain/rpc.rs`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (the complete public surface of `chain/rpc.rs` after this task):
+  - `pub const CHECK_DEADLINE: Duration = Duration::from_secs(4);`
+  - `pub async fn check_url(rpc_url: &str, expected_chain_id: u64) -> Result<()>` — single-URL validation, NO deadline (explicit validation paths keep the provider's own 10s connect timeout). `test_rpc` is folded into it.
+  - `pub async fn probe(url: &str, expected_chain_id: u64) -> (bool, Duration)` — one health probe under `CHECK_DEADLINE`, with latency. The single definition used by sweeps.
+  - `pub struct ProbeResult { pub index: usize, pub healthy: bool, pub latency: Duration }`
+  - `pub fn probe_urls(urls: &[String], expected_chain_id: u64) -> tokio::sync::mpsc::Receiver<ProbeResult>` — yields exactly `urls.len()` results in completion order.
+  - `pub fn rank_by_health(results: &[ProbeResult]) -> Vec<usize>` — healthy ascending by latency, then unhealthy in original index order.
+  - `pub async fn check_urls(urls: &[String], expected_chain_id: u64) -> Vec<bool>` — collecting wrapper over `probe_urls` (used by doctor `--fix`).
+- **Deletes** (collapse onto the new seam — verify with grep before finishing):
+  - `Rpc` struct and `impl Display for Rpc` (chain/mod.rs) — its only job was pairing a URL with a provider nobody reads outside the check itself
+  - `resolve_rpc`, `resolve_rpcs` (rpc.rs) and the `pub use rpc::{resolve_rpc, resolve_rpcs}` re-export (chain/mod.rs)
+  - `test_rpc` (folded into `check_url`)
+  - `create_provider` becomes private (`fn`, not `pub fn`)
+  - Callers in wizard.rs are updated in Task 4; this task may leave wizard.rs temporarily calling shims — do Tasks 3+4 in one PR-worth of commits, compile green at each commit by updating wizard call sites in the same commit where their callee is deleted.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/chain/rpc.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn result(index: usize, healthy: bool, ms: u64) -> ProbeResult {
+        ProbeResult {
+            index,
+            healthy,
+            latency: Duration::from_millis(ms),
+        }
+    }
+
+    #[test]
+    fn rank_healthy_fastest_first_then_unhealthy_in_order() {
+        let results = vec![
+            result(0, false, 4000),
+            result(1, true, 150),
+            result(2, true, 20),
+            result(3, false, 4000),
+        ];
+        assert_eq!(rank_by_health(&results), vec![2, 1, 0, 3]);
+    }
+
+    #[tokio::test]
+    async fn probe_urls_reports_every_url() {
+        // connection-refused fails fast; no network needed
+        let urls = vec![
+            "http://localhost:1".to_string(),
+            "http://localhost:2".to_string(),
+        ];
+        let mut rx = probe_urls(&urls, 1);
+        let mut seen = Vec::new();
+        while let Some(result) = rx.recv().await {
+            assert!(!result.healthy);
+            seen.push(result.index);
+        }
+        seen.sort();
+        assert_eq!(seen, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    async fn probe_urls_empty_input_closes_immediately() {
+        let mut rx = probe_urls(&[], 1);
+        assert!(rx.recv().await.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test chain::rpc 2>&1 | tail -5`
+Expected: compile error — `ProbeResult`/`probe_urls`/`rank_by_health` not found.
+
+- [ ] **Step 3: Implement the new surface and delete the old one**
+
+Rewrite `src/chain/rpc.rs` to exactly this shape (plus the existing `use` lines for alloy/anyhow):
+
+```rust
+use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use anyhow::Result;
+use std::time::{Duration, Instant};
+
+/// Global deadline for a single RPC health probe in interactive sweeps.
+pub const CHECK_DEADLINE: Duration = Duration::from_secs(4);
+
+/// Test whether an (already-expanded) RPC URL serves the expected chain id.
+/// No sweep deadline: explicit single-URL validation keeps the provider's
+/// own 10s connect timeout. The single definition of "is this RPC healthy".
+pub async fn check_url(rpc_url: &str, expected_chain_id: u64) -> Result<()> {
+    let provider = create_provider(rpc_url).await?;
+    let chain_id = provider
+        .get_chain_id()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to {}: {}", rpc_url, e))?;
+    if chain_id != expected_chain_id {
+        anyhow::bail!(
+            "Chain ID mismatch on {}: expected {}, got {}",
+            rpc_url,
+            expected_chain_id,
+            chain_id
+        );
+    }
+    Ok(())
+}
+
+/// One health probe under CHECK_DEADLINE, with measured latency.
+pub async fn probe(url: &str, expected_chain_id: u64) -> (bool, Duration) {
+    let start = Instant::now();
+    let healthy = tokio::time::timeout(CHECK_DEADLINE, check_url(url, expected_chain_id))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false);
+    (healthy, start.elapsed())
+}
+
+pub struct ProbeResult {
+    pub index: usize,
+    pub healthy: bool,
+    pub latency: Duration,
+}
+
+/// Probe URLs concurrently, yielding each result as it lands (completion
+/// order). The receiver yields exactly `urls.len()` results, then closes.
+pub fn probe_urls(
+    urls: &[String],
+    expected_chain_id: u64,
+) -> tokio::sync::mpsc::Receiver<ProbeResult> {
+    let (tx, rx) = tokio::sync::mpsc::channel(urls.len().max(1));
+    for (index, url) in urls.iter().cloned().enumerate() {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let (healthy, latency) = probe(&url, expected_chain_id).await;
+            let _ = tx
+                .send(ProbeResult {
+                    index,
+                    healthy,
+                    latency,
+                })
+                .await;
+        });
+    }
+    rx
+}
+
+/// Picker ordering: healthy probes fastest-first, then unhealthy ones in
+/// their original order.
+pub fn rank_by_health(results: &[ProbeResult]) -> Vec<usize> {
+    let mut healthy: Vec<&ProbeResult> = results.iter().filter(|r| r.healthy).collect();
+    healthy.sort_by_key(|r| r.latency);
+    let mut unhealthy: Vec<&ProbeResult> = results.iter().filter(|r| !r.healthy).collect();
+    unhealthy.sort_by_key(|r| r.index);
+    healthy
+        .into_iter()
+        .chain(unhealthy)
+        .map(|r| r.index)
+        .collect()
+}
+
+/// Collecting wrapper: one health flag per input URL, in input order.
+pub async fn check_urls(urls: &[String], expected_chain_id: u64) -> Vec<bool> {
+    let mut results = vec![false; urls.len()];
+    let mut rx = probe_urls(urls, expected_chain_id);
+    while let Some(result) = rx.recv().await {
+        results[result.index] = result.healthy;
+    }
+    results
+}
+
+async fn create_provider(rpc_url: &str) -> Result<DynProvider> {
+    let provider = tokio::time::timeout(
+        Duration::from_secs(10),
+        ProviderBuilder::new().connect(rpc_url),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("RPC connection timed out: {}", rpc_url))??;
+    Ok(provider.erased())
+}
+```
+
+Note what is GONE from this file: `Rpc`, `resolve_rpc`, `resolve_rpcs`, `test_rpc`; `create_provider` is now private. In `src/chain/mod.rs`: delete the `Rpc` struct, its `Display` impl, and the `pub use rpc::{resolve_rpc, resolve_rpcs};` line. Task 4 updates the wizard call sites — to keep every commit green, land Task 3 + Task 4 wizard updates in the same commit if the intermediate state doesn't compile.
+
+Verify the collapse: `grep -rn "resolve_rpc\|test_rpc\|Rpc {" src/` — expected: no hits outside comments after Task 4.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test chain::rpc 2>&1 | tail -4` then `cargo test 2>&1 | grep 'test result'`
+Expected: new tests pass; full suite stays green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && git add -A && git commit -m "feat: streaming RPC probes with 4s deadline and health ranking"
+```
+
+---
+
+### Task 4: Live-updating RPC test in the wizard; raw-URL boundary
+
+**Files:**
+- Modify: `src/chain/wizard.rs` (`select_rpc`, `select_manual_rpc`, `UpdateArgs::handle`, `AddArgs::handle_interactive`, `AddArgs::handle_non_interactive`)
+
+**Interfaces:**
+- Consumes: `probe_urls`, `rank_by_health`, `ProbeResult`, `check_url` (Task 3); `ui::success/fail/dim/emph` (Task 1); `GlobalVariables::expand_rpc_url`.
+- Produces: `pub async fn select_rpc(chain_name: &str, chain_id: u64, urls: Vec<String>, globals: &GlobalVariables) -> Result<String>` — takes and **returns raw URLs**; expansion happens only for probing. `select_manual_rpc(chain_id: u64, globals: &GlobalVariables) -> Result<String>` likewise returns the raw URL the user typed.
+- Boundary being enforced: raw URLs on screen and in config (no API keys displayed or persisted); expanded URLs exist only inside probe calls. This *fixes* the old flow, which displayed and stored expanded URLs.
+
+- [ ] **Step 1: Rewrite `select_rpc`**
+
+```rust
+use crate::ui;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+/// Pick an RPC for a chain. `urls` are raw (may contain ${VAR}); they are
+/// expanded only for probing. Displays and returns raw URLs so secrets are
+/// never shown on screen or written to config.
+pub async fn select_rpc(
+    chain_name: &str,
+    chain_id: u64,
+    urls: Vec<String>,
+    globals: &GlobalVariables,
+) -> Result<String> {
+    let expanded: Vec<String> = urls.iter().map(|u| globals.expand_rpc_url(u)).collect();
+
+    // Live per-RPC status lines; hidden automatically when not a TTY
+    let multi = MultiProgress::new();
+    let bars: Vec<ProgressBar> = urls
+        .iter()
+        .map(|url| {
+            let bar = multi.add(ProgressBar::new_spinner());
+            bar.set_style(ProgressStyle::with_template("{spinner} {msg}").unwrap());
+            bar.enable_steady_tick(std::time::Duration::from_millis(120));
+            bar.set_message(url.clone());
+            bar
+        })
+        .collect();
+
+    let mut results = Vec::with_capacity(urls.len());
+    let mut rx = probe_urls(&expanded, chain_id);
+    while let Some(result) = rx.recv().await {
+        let bar = &bars[result.index];
+        if result.healthy {
+            bar.finish_with_message(ui::success(&format!(
+                "{}  {}ms",
+                urls[result.index],
+                result.latency.as_millis()
+            )));
+        } else {
+            bar.finish_with_message(ui::fail(&format!(
+                "{}  {}",
+                urls[result.index],
+                ui::dim("unreachable")
+            )));
+        }
+        results.push(result);
+    }
+
+    // Healthy-first, fastest-first picker over RAW urls
+    let order = rank_by_health(&results);
+    let mut items: Vec<String> = order
+        .iter()
+        .map(|&i| {
+            let r = results.iter().find(|r| r.index == i).unwrap();
+            if r.healthy {
+                format!("{} ({}ms)", urls[i], r.latency.as_millis())
+            } else {
+                format!("{} (unreachable)", urls[i])
+            }
+        })
+        .collect();
+    items.push("Enter RPC URL manually...".to_string());
+
+    let selection = fuzzy_select(
+        &format!("Select an RPC URL for {}", ui::emph(chain_name)),
+        &items,
+        0,
+    )?;
+
+    if selection == items.len() - 1 {
+        select_manual_rpc(chain_id, globals).await
+    } else {
+        Ok(urls[order[selection]].clone())
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `select_manual_rpc` (returns raw String, uses check_url)**
+
+```rust
+async fn select_manual_rpc(chain_id: u64, globals: &GlobalVariables) -> Result<String> {
+    loop {
+        let rpc_url: String = text_input("Enter RPC URL", None)?;
+        println!("Testing RPC...");
+        if check_url(&globals.expand_rpc_url(&rpc_url), chain_id)
+            .await
+            .is_ok()
+        {
+            println!("{}", ui::success("RPC working"));
+            return Ok(rpc_url);
+        }
+        println!("{}", ui::fail("RPC failed. Try again? (ESC to exit)"));
+    }
+}
+```
+
+- [ ] **Step 3: Update the three call sites**
+
+`UpdateArgs::handle` (RPC branch) — no more `resolve_rpcs`:
+
+```rust
+let available_rpcs = chainlist_entry
+    .map(|c| c.rpc)
+    .unwrap_or_else(|_| chain.rpc_urls.clone());
+let new_rpc = select_rpc(
+    &chain.name,
+    chain.chain_id,
+    available_rpcs,
+    &chainz.config.globals,
+)
+.await?;
+chain.selected_rpc = new_rpc;
+```
+
+`AddArgs::handle_interactive` — RPC selection branch:
+
+```rust
+select_rpc(
+    &name,
+    selected_chain.chain_id,
+    selected_chain.rpc.clone(),
+    &chainz.config.globals,
+)
+.await?
+```
+
+and its explicit `--rpc-url` branch plus `handle_non_interactive`'s test both become (the id expression is `selected_chain.chain_id` in the interactive branch and the local `chain_id` in `handle_non_interactive`):
+
+```rust
+println!("Testing RPC...");
+check_url(
+    &chainz.config.globals.expand_rpc_url(rpc_url),
+    selected_chain.chain_id, // `chain_id` in handle_non_interactive
+)
+.await?;
+println!("{}", crate::ui::success("RPC working"));
+```
+
+Update the wizard's imports: `use super::rpc::{check_url, probe_urls, rank_by_health};` — `Rpc`, `resolve_rpc`, `resolve_rpcs`, `test_rpc`, `create_provider` no longer exist.
+
+- [ ] **Step 4: Verify the collapse and the suite**
+
+Run: `grep -rn "resolve_rpc\|test_rpc\|Rpc" src/ | grep -v ProbeResult | grep -v rpc_url | grep -v check` — expected: no hits.
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test 2>&1 | grep 'test result'`
+Expected: all green (ranking logic covered by Task 3; wizard path is interactive).
+
+- [ ] **Step 5: Manual smoke (needs a TTY)**
+
+Run: `cargo run -- add`, observe: spinners resolve individually, picker opens ≤4s after the slowest probe, healthy RPCs first with latencies, raw `${VAR}` URLs shown unexpanded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: live latency-ranked RPC picker; raw-URL display/storage boundary"
+```
+
+---
+
+### Task 5: Doctor uses the probe stream
+
+**Files:**
+- Modify: `src/doctor.rs` (`check_rpc_health`)
+
+**Interfaces:**
+- Consumes: `probe` (Task 3 — chains have different expected ids, so one `probe` per chain, all spawned concurrently as today), `ui` helpers.
+- Produces: `check_rpc_health` keeps its signature; per-chain output line gains latency and shows the **raw** URL: `✓ ethereum (https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}) 89ms`.
+
+- [ ] **Step 1: Rework the sweep**
+
+The per-chain task body becomes a single `probe` call (drop the local `healthy` helper — `probe` owns the deadline and latency). Note: expand for the probe, display the raw URL (Global Constraints raw-vs-expanded rule — the old code printed expanded URLs, leaking keys to screen):
+
+```rust
+let checks: Vec<_> = chains
+    .iter()
+    .map(|c| {
+        let expanded = chainz.config.globals.expand_rpc_url(&c.selected_rpc);
+        let raw = c.selected_rpc.clone();
+        let chain_id = c.chain_id;
+        let name = c.name.clone();
+        tokio::spawn(async move {
+            let (healthy, latency) = crate::chain::rpc::probe(&expanded, chain_id).await;
+            (name, healthy, raw, latency)
+        })
+    })
+    .collect();
+
+let mut failed = Vec::new();
+for handle in checks {
+    let Ok((name, is_healthy, raw_url, latency)) = handle.await else {
+        continue;
+    };
+    if is_healthy {
+        println!(
+            "  {}",
+            ui::success(&format!("{} ({}) {}ms", name, raw_url, latency.as_millis()))
+        );
+    } else {
+        report.failures += 1;
+        println!("  {}", ui::fail(&format!("{} ({})", name, raw_url)));
+        failed.push(name);
+    }
+}
+```
+
+- [ ] **Step 2: Fix the raw-URL leak in `fix_rpcs`**
+
+In `fix_rpcs`, the success line currently prints `expanded[i]`; change it to the raw candidate so switched-to URLs with `${VAR}` never render expanded:
+
+```rust
+println!(
+    "  {}",
+    ui::success(&format!("{}: switched to {}", name, candidates[i]))
+);
+```
+
+- [ ] **Step 3: Verify (integration contract)**
+
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test 2>&1 | grep 'test result'`
+Expected: green — `doctor_reports_dead_rpc_and_exits_nonzero` still matches (the ✗ line still contains the chain name; failure summary unchanged). If a test asserts on text that changed, fix the assertion to the new line shape — the *contract* (name present, nonzero exit) is what matters.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat: doctor health sweep shows latency, honors 4s probe deadline"
+```
+
+---
+
+### Task 6: Chainlist download progress bar
+
+**Files:**
+- Modify: `src/chainlist.rs` (`fetch_from_network`)
+
+**Interfaces:**
+- Consumes: `indicatif::{ProgressBar, ProgressStyle}`.
+- Produces: `fetch_from_network` keeps its `-> Result<String>` signature; body is streamed with a byte progress bar (auto-hidden when not a TTY), spinner fallback when content-length is unknown.
+
+- [ ] **Step 1: Implement streaming download**
+
+```rust
+async fn fetch_from_network() -> Result<String> {
+    use indicatif::{ProgressBar, ProgressStyle};
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let mut response = client
+        .get(CHAINLIST_URL)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let bar = match response.content_length() {
+        Some(len) => {
+            let bar = ProgressBar::new(len);
+            bar.set_style(
+                ProgressStyle::with_template(
+                    "downloading chainlist {bytes}/{total_bytes} [{bar:30}] {eta}",
+                )
+                .unwrap(),
+            );
+            bar
+        }
+        None => {
+            let bar = ProgressBar::new_spinner();
+            bar.set_message("downloading chainlist…");
+            bar
+        }
+    };
+
+    let mut body = Vec::with_capacity(response.content_length().unwrap_or(0) as usize);
+    while let Some(chunk) = response.chunk().await? {
+        body.extend_from_slice(&chunk);
+        bar.inc(chunk.len() as u64);
+    }
+    bar.finish_and_clear();
+    Ok(String::from_utf8(body)?)
+}
+```
+
+Note the overall timeout rises 10s → 30s: the old 10s covered header-arrival for a small request; a multi-MB streamed body on slow links needs headroom, and progress is now visible so waiting is honest.
+
+- [ ] **Step 2: Verify**
+
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test 2>&1 | grep 'test result'`
+Expected: green (chainlist deserialization tests unaffected).
+
+Manual smoke: `cargo run -- add --refresh` on a TTY shows the byte bar.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat: progress bar for chainlist download"
+```
+
+---
+
+### Task 7: `chainz shell`
+
+**Files:**
+- Modify: `src/opt.rs` (new `Shell` command)
+- Modify: `src/main.rs` (handler)
+- Test: `tests/cli.rs`
+
+**Interfaces:**
+- Consumes: `ChainVariables::new(&chain, &[])` (no args → lazy rule keeps key backends untouched), exec's chain resolution pattern, `ui::item/dim`.
+- Produces: `chainz shell [name_or_id]` — spawns `$SHELL` (fallback `sh`) with chain env + `CHAINZ_CHAIN`, PS1 prefixed `(⛓ <chain>) `, exit code passthrough.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/cli.rs`:
+
+```rust
+#[test]
+fn shell_sets_env_and_passes_exit_code() {
+    let home = TempDir::new().unwrap();
+    seed_config(home.path(), &[("testchain", 31337)]);
+
+    // A fake "shell" that proves env vars arrive and exit codes pass through
+    let fake_shell = home.path().join("fakeshell.sh");
+    fs::write(
+        &fake_shell,
+        "#!/bin/sh\necho chain=$CHAINZ_CHAIN rpc=$ETH_RPC_URL key=${RAW_PRIVATE_KEY:-unset}\nexit 3\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_shell, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    chainz(home.path())
+        .env("SHELL", &fake_shell)
+        .args(["shell", "testchain"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains(
+            "chain=testchain rpc=http://localhost:1 key=unset",
+        ));
+}
+
+#[test]
+fn shell_uses_default_chain_when_omitted() {
+    let home = TempDir::new().unwrap();
+    seed_config(home.path(), &[("testchain", 31337)]);
+    chainz(home.path())
+        .args(["use", "testchain"])
+        .assert()
+        .success();
+
+    let fake_shell = home.path().join("fakeshell.sh");
+    fs::write(&fake_shell, "#!/bin/sh\necho in=$CHAINZ_CHAIN\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_shell, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    chainz(home.path())
+        .env("SHELL", &fake_shell)
+        .arg("shell")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("in=testchain"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --test cli shell 2>&1 | tail -5`
+Expected: FAIL — `unrecognized subcommand 'shell'`.
+
+- [ ] **Step 3: Add the command**
+
+`src/opt.rs`, after `Exec` in `Command`:
+
+```rust
+/// Open a subshell with the chain's environment loaded
+///
+/// Sets ETH_RPC_URL, CHAIN_ID, CHAIN_NAME, VERIFIER_* and CHAINZ_CHAIN,
+/// and prefixes PS1 with the chain name for bash-like shells.
+/// Key material is NOT loaded into the environment.
+///
+/// Example: chainz shell base
+Shell {
+    /// Chain name or ID (default chain or interactive picker if omitted)
+    name_or_id: Option<String>,
+},
+```
+
+`src/main.rs`, new arm next to `Exec` (before it, order cosmetic):
+
+```rust
+opt::Command::Shell { name_or_id } => {
+    let name_or_id = match name_or_id.or_else(|| chainz.config.default_chain.clone()) {
+        Some(id) => id,
+        None => select_chain(&chainz)?,
+    };
+    let chain = chainz.get_chain(&name_or_id)?;
+    // Empty command args → lazy rule: key backends are never touched
+    let variables = ChainVariables::new(&chain, &[])?;
+    let chain_name = chain.definition.name.clone();
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+
+    eprintln!(
+        "{}",
+        ui::item(&format!("entering {} shell — ctrl-d to exit", chain_name))
+    );
+    let ps1 = format!(
+        "(⛓ {}) {}",
+        chain_name,
+        std::env::var("PS1").unwrap_or_default()
+    );
+    let status = ProcessCommand::new(&shell)
+        .envs(variables.as_map())
+        .env("CHAINZ_CHAIN", &chain_name)
+        .env("PS1", ps1)
+        .status()?;
+    eprintln!("{}", ui::dim(&format!("left {} shell", chain_name)));
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+```
+
+Add `use chainz::ui;` to main.rs imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --test cli shell 2>&1 | tail -4` then full `cargo test 2>&1 | grep 'test result'`
+Expected: both new tests pass; suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt && git add -A && git commit -m "feat: chainz shell — subshell with chain env and prompt indicator"
+```
+
+---
+
+### Task 8: README + final verification
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: documented `shell` command, prompt snippet, probe-deadline note.
+
+- [ ] **Step 1: Document**
+
+In README Quick Start, replace the `chainz exec ethereum -- bash` subshell example with:
+
+```bash
+# Open a subshell with chain environment (prompt shows the chain)
+chainz shell ethereum
+```
+
+Add under Usage, after "Executing Commands":
+
+```markdown
+### Chain Shells
+
+`chainz shell [chain]` opens your `$SHELL` with the chain's environment
+(`ETH_RPC_URL`, `CHAIN_ID`, `CHAIN_NAME`, `VERIFIER_*`, `CHAINZ_CHAIN`) —
+private keys are never injected. Bash prompts get a `(⛓ ethereum)` prefix
+automatically; for zsh/starship, add e.g.:
+
+    # starship.toml
+    [env_var.CHAINZ_CHAIN]
+    format = "(⛓ $env_value) "
+```
+
+In the RPC section, note: interactive RPC tests and `doctor` probes time out after 4 seconds per endpoint; results stream in live and pickers list healthy endpoints fastest-first.
+
+- [ ] **Step 2: Full verification**
+
+Run: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test 2>&1 | grep 'test result'`
+Expected: everything green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "docs: shell command, prompt snippet, probe deadline"
+```

--- a/docs/superpowers/specs/2026-07-16-phase4-design.md
+++ b/docs/superpowers/specs/2026-07-16-phase4-design.md
@@ -96,9 +96,19 @@ Env-var use stays silent. No hard break.
 
 ### Streaming RPC checks
 
-- `check_urls` becomes a stream of `(index, latency, result)` events as
-  probes complete (data layer, no TTY knowledge). A render layer consumes
-  the stream.
+- Probing becomes an event stream: `probe(url, chain_id) -> (healthy,
+  latency)` is the single deadline-bearing health check; `probe_urls`
+  fans it out and yields `ProbeResult { index, healthy, latency }` events
+  in completion order (data layer, no TTY knowledge). `check_urls` remains
+  as a collecting wrapper. A render layer consumes the stream.
+- **Collapse:** the old `Rpc` struct (URL + live provider pair),
+  `resolve_rpc`, `resolve_rpcs`, and `test_rpc` are deleted;
+  `create_provider` becomes private. `select_rpc` takes plain URL strings.
+- **Raw-vs-expanded boundary:** pickers, doctor output, and config storage
+  always use raw URLs (`${VAR}` intact); expansion happens only inside
+  probe calls and exec-time resolution. This fixes the old flow, which
+  displayed expanded URLs on screen and stored them into `selected_rpc`
+  (baking API keys into the config).
 - `add` wizard: per-RPC lines update live (`⋯ → ✓ 89ms / ✗ timeout`) under
   an elapsed-time spinner; a **~4s global deadline** replaces the 10s worst
   case; unfinished probes render as timeouts; the picker opens immediately

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -2,8 +2,9 @@ pub mod rpc;
 pub mod wizard;
 
 use crate::key::Key;
+use crate::ui;
 use alloy::providers::DynProvider;
-use colored::*;
+use console::style;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -82,56 +83,54 @@ impl Display for ChainDefinition {
         writeln!(
             f,
             "{}: {}{}",
-            "Chain".bright_blue().bold(),
-            self.name.yellow(),
+            style("Chain").cyan().bold(),
+            ui::emph(&self.name),
             if self.aliases.is_empty() {
                 String::new()
             } else {
-                format!(" ({})", self.aliases.join(", "))
-                    .bright_black()
-                    .to_string()
+                ui::dim(&format!(" ({})", self.aliases.join(", ")))
             }
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "ID".bright_blue(),
-            self.chain_id.to_string().yellow()
+            style("├").dim(),
+            style("ID").cyan(),
+            ui::emph(&self.chain_id.to_string())
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "Active RPC".bright_blue(),
-            self.selected_rpc.bright_green()
+            style("├").dim(),
+            style("Active RPC").cyan(),
+            style(&self.selected_rpc).green()
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "Verification URL".bright_blue(),
+            style("├").dim(),
+            style("Verification URL").cyan(),
             self.verification_url
                 .as_deref()
-                .map(|k| k.bright_green().to_string())
-                .unwrap_or_else(|| "None".bright_red().to_string())
+                .map(|k| style(k).green().to_string())
+                .unwrap_or_else(|| style("None").red().to_string())
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "Verification Key".bright_blue(),
+            style("├").dim(),
+            style("Verification Key").cyan(),
             self.verification_api_key
                 .as_deref()
-                .map(|k| k.bright_green().to_string())
-                .unwrap_or_else(|| "None".bright_red().to_string())
+                .map(|k| style(k).green().to_string())
+                .unwrap_or_else(|| style("None").red().to_string())
         )?;
         write!(
             f,
             "{}─ {}: {}",
-            "└".bright_black(),
-            "Key Name".bright_blue(),
-            self.key_name.bright_green(),
+            style("└").dim(),
+            style("Key Name").cyan(),
+            style(&self.key_name).green(),
         )
     }
 }
@@ -141,32 +140,32 @@ impl Display for ChainInstance {
         writeln!(
             f,
             "{}: {}",
-            "Chain".bright_blue().bold(),
-            self.definition.name.yellow()
+            style("Chain").cyan().bold(),
+            ui::emph(&self.definition.name)
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "ID".bright_blue(),
-            self.definition.chain_id.to_string().yellow()
+            style("├").dim(),
+            style("ID").cyan(),
+            ui::emph(&self.definition.chain_id.to_string())
         )?;
         writeln!(
             f,
             "{}─ {}: {}",
-            "├".bright_black(),
-            "RPC".bright_blue(),
-            self.rpc_url.bright_green()
+            style("├").dim(),
+            style("RPC").cyan(),
+            style(&self.rpc_url).green()
         )?;
         write!(
             f,
             "{}─ {}: {}",
-            "└".bright_black(),
-            "Wallet".bright_blue(),
+            style("└").dim(),
+            style("Wallet").cyan(),
             self.key
                 .address()
-                .map(|addr| addr.to_string().bright_green())
-                .unwrap_or("None".bright_red())
+                .map(|addr| style(addr.to_string()).green().to_string())
+                .unwrap_or_else(|_| style("None").red().to_string())
         )
     }
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -3,12 +3,9 @@ pub mod wizard;
 
 use crate::key::Key;
 use crate::ui;
-use alloy::providers::DynProvider;
 use console::style;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
-
-pub use rpc::{resolve_rpc, resolve_rpcs};
 
 pub const DEFAULT_KEY_NAME: &str = "default";
 
@@ -64,17 +61,6 @@ impl ChainInstance {
     pub fn with_key(mut self, key: Key) -> Self {
         self.key = key;
         self
-    }
-}
-
-pub struct Rpc {
-    pub rpc_url: String,
-    pub provider: DynProvider,
-}
-
-impl Display for Rpc {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.rpc_url)
     }
 }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -121,41 +121,6 @@ impl Display for ChainDefinition {
     }
 }
 
-impl Display for ChainInstance {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(
-            f,
-            "{}: {}",
-            style("Chain").cyan().bold(),
-            ui::emph(&self.definition.name)
-        )?;
-        writeln!(
-            f,
-            "{}─ {}: {}",
-            style("├").dim(),
-            style("ID").cyan(),
-            ui::emph(&self.definition.chain_id.to_string())
-        )?;
-        writeln!(
-            f,
-            "{}─ {}: {}",
-            style("├").dim(),
-            style("RPC").cyan(),
-            style(&self.rpc_url).green()
-        )?;
-        write!(
-            f,
-            "{}─ {}: {}",
-            style("└").dim(),
-            style("Wallet").cyan(),
-            self.key
-                .address()
-                .map(|addr| style(addr.to_string()).green().to_string())
-                .unwrap_or_else(|_| style("None").red().to_string())
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chain/rpc.rs
+++ b/src/chain/rpc.rs
@@ -8,16 +8,19 @@ pub const CHECK_DEADLINE: Duration = Duration::from_secs(4);
 /// Test whether an (already-expanded) RPC URL serves the expected chain id.
 /// No sweep deadline: explicit single-URL validation keeps the provider's
 /// own 10s connect timeout. The single definition of "is this RPC healthy".
+///
+/// Error messages deliberately omit the URL (it may embed API keys); callers
+/// that report failures to the user should attach the *raw* (unexpanded)
+/// URL as context themselves.
 pub async fn check_url(rpc_url: &str, expected_chain_id: u64) -> Result<()> {
     let provider = create_provider(rpc_url).await?;
     let chain_id = provider
         .get_chain_id()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to connect to {}: {}", rpc_url, e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to connect: {}", e))?;
     if chain_id != expected_chain_id {
         anyhow::bail!(
-            "Chain ID mismatch on {}: expected {}, got {}",
-            rpc_url,
+            "Chain ID mismatch: expected {}, got {}",
             expected_chain_id,
             chain_id
         );
@@ -94,7 +97,7 @@ async fn create_provider(rpc_url: &str) -> Result<DynProvider> {
         ProviderBuilder::new().connect(rpc_url),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("RPC connection timed out: {}", rpc_url))??;
+    .map_err(|_| anyhow::anyhow!("RPC connection timed out"))??;
     Ok(provider.erased())
 }
 

--- a/src/chain/rpc.rs
+++ b/src/chain/rpc.rs
@@ -1,18 +1,23 @@
-use super::Rpc;
-use crate::variables::GlobalVariables;
 use alloy::providers::{DynProvider, Provider, ProviderBuilder};
 use anyhow::Result;
+use std::time::{Duration, Instant};
 
-pub async fn test_rpc(rpc: &Rpc, expected_chain_id: u64) -> Result<()> {
-    let chain_id = rpc
-        .provider
+/// Global deadline for a single RPC health probe in interactive sweeps.
+pub const CHECK_DEADLINE: Duration = Duration::from_secs(4);
+
+/// Test whether an (already-expanded) RPC URL serves the expected chain id.
+/// No sweep deadline: explicit single-URL validation keeps the provider's
+/// own 10s connect timeout. The single definition of "is this RPC healthy".
+pub async fn check_url(rpc_url: &str, expected_chain_id: u64) -> Result<()> {
+    let provider = create_provider(rpc_url).await?;
+    let chain_id = provider
         .get_chain_id()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to connect to {}: {}", rpc.rpc_url, e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to connect to {}: {}", rpc_url, e))?;
     if chain_id != expected_chain_id {
         anyhow::bail!(
             "Chain ID mismatch on {}: expected {}, got {}",
-            rpc.rpc_url,
+            rpc_url,
             expected_chain_id,
             chain_id
         );
@@ -20,60 +25,123 @@ pub async fn test_rpc(rpc: &Rpc, expected_chain_id: u64) -> Result<()> {
     Ok(())
 }
 
-pub async fn resolve_rpcs(rpc_urls: Vec<String>, globals: &GlobalVariables) -> Result<Vec<Rpc>> {
-    let mut result = Vec::new();
-    for rpc in rpc_urls {
-        if let Ok(r) = resolve_rpc(&rpc, globals).await {
-            result.push(r);
-        }
+/// One health probe under CHECK_DEADLINE, with measured latency.
+pub async fn probe(url: &str, expected_chain_id: u64) -> (bool, Duration) {
+    let start = Instant::now();
+    let healthy = tokio::time::timeout(CHECK_DEADLINE, check_url(url, expected_chain_id))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false);
+    (healthy, start.elapsed())
+}
+
+pub struct ProbeResult {
+    pub index: usize,
+    pub healthy: bool,
+    pub latency: Duration,
+}
+
+/// Probe URLs concurrently, yielding each result as it lands (completion
+/// order). The receiver yields exactly `urls.len()` results, then closes.
+pub fn probe_urls(
+    urls: &[String],
+    expected_chain_id: u64,
+) -> tokio::sync::mpsc::Receiver<ProbeResult> {
+    let (tx, rx) = tokio::sync::mpsc::channel(urls.len().max(1));
+    for (index, url) in urls.iter().cloned().enumerate() {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let (healthy, latency) = probe(&url, expected_chain_id).await;
+            let _ = tx
+                .send(ProbeResult {
+                    index,
+                    healthy,
+                    latency,
+                })
+                .await;
+        });
     }
-    Ok(result)
+    rx
 }
 
-pub async fn resolve_rpc(rpc_url: &str, globals: &GlobalVariables) -> Result<Rpc> {
-    let rpc_url = globals.expand_rpc_url(rpc_url);
-    Ok(Rpc {
-        rpc_url: rpc_url.clone(),
-        provider: create_provider(&rpc_url).await?,
-    })
+/// Picker ordering: healthy probes fastest-first, then unhealthy ones in
+/// their original order.
+pub fn rank_by_health(results: &[ProbeResult]) -> Vec<usize> {
+    let mut healthy: Vec<&ProbeResult> = results.iter().filter(|r| r.healthy).collect();
+    healthy.sort_by_key(|r| r.latency);
+    let mut unhealthy: Vec<&ProbeResult> = results.iter().filter(|r| !r.healthy).collect();
+    unhealthy.sort_by_key(|r| r.index);
+    healthy
+        .into_iter()
+        .chain(unhealthy)
+        .map(|r| r.index)
+        .collect()
 }
 
-/// Test whether an (already-expanded) RPC URL serves the expected chain id.
-/// The single definition of "is this RPC healthy" — used by the add/update
-/// wizard and by `chainz doctor`.
-pub async fn check_url(rpc_url: &str, expected_chain_id: u64) -> Result<()> {
-    let provider = create_provider(rpc_url).await?;
-    test_rpc(
-        &Rpc {
-            rpc_url: rpc_url.to_string(),
-            provider,
-        },
-        expected_chain_id,
-    )
-    .await
-}
-
-/// Concurrently check many (already-expanded) RPC URLs against an expected
-/// chain id. Returns one health flag per input URL, in order.
+/// Collecting wrapper: one health flag per input URL, in input order.
 pub async fn check_urls(urls: &[String], expected_chain_id: u64) -> Vec<bool> {
-    let handles: Vec<_> = urls
-        .iter()
-        .cloned()
-        .map(|url| tokio::spawn(async move { check_url(&url, expected_chain_id).await.is_ok() }))
-        .collect();
-    let mut results = Vec::with_capacity(handles.len());
-    for handle in handles {
-        results.push(handle.await.unwrap_or(false));
+    let mut results = vec![false; urls.len()];
+    let mut rx = probe_urls(urls, expected_chain_id);
+    while let Some(result) = rx.recv().await {
+        results[result.index] = result.healthy;
     }
     results
 }
 
-pub async fn create_provider(rpc_url: &str) -> Result<DynProvider> {
+async fn create_provider(rpc_url: &str) -> Result<DynProvider> {
     let provider = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
+        Duration::from_secs(10),
         ProviderBuilder::new().connect(rpc_url),
     )
     .await
     .map_err(|_| anyhow::anyhow!("RPC connection timed out: {}", rpc_url))??;
     Ok(provider.erased())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn result(index: usize, healthy: bool, ms: u64) -> ProbeResult {
+        ProbeResult {
+            index,
+            healthy,
+            latency: Duration::from_millis(ms),
+        }
+    }
+
+    #[test]
+    fn rank_healthy_fastest_first_then_unhealthy_in_order() {
+        let results = vec![
+            result(0, false, 4000),
+            result(1, true, 150),
+            result(2, true, 20),
+            result(3, false, 4000),
+        ];
+        assert_eq!(rank_by_health(&results), vec![2, 1, 0, 3]);
+    }
+
+    #[tokio::test]
+    async fn probe_urls_reports_every_url() {
+        // connection-refused fails fast; no network needed
+        let urls = vec![
+            "http://localhost:1".to_string(),
+            "http://localhost:2".to_string(),
+        ];
+        let mut rx = probe_urls(&urls, 1);
+        let mut seen = Vec::new();
+        while let Some(result) = rx.recv().await {
+            assert!(!result.healthy);
+            seen.push(result.index);
+        }
+        seen.sort();
+        assert_eq!(seen, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    async fn probe_urls_empty_input_closes_immediately() {
+        let mut rx = probe_urls(&[], 1);
+        assert!(rx.recv().await.is_none());
+    }
 }

--- a/src/chain/wizard.rs
+++ b/src/chain/wizard.rs
@@ -1,6 +1,6 @@
 use super::{
     ChainDefinition, DEFAULT_KEY_NAME,
-    rpc::{check_url, check_urls},
+    rpc::{check_url, probe_urls, rank_by_health},
 };
 use crate::ui;
 use crate::{
@@ -13,6 +13,7 @@ use crate::{
 use anyhow::Result;
 use console::style;
 use dialoguer::{FuzzySelect, Input};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 /// Helper function to handle text input with ESC cancellation
 fn text_input<T: std::str::FromStr>(prompt: &str, default: Option<String>) -> Result<T>
@@ -59,55 +60,75 @@ pub async fn manual_chain_entry(
     })
 }
 
-/// Helper function to select or enter RPC URL.
-/// `available_rpcs` are raw (unexpanded) URLs; they are only expanded for
-/// the health probe itself and stored/displayed raw.
+/// Pick an RPC for a chain. `urls` are raw (may contain ${VAR}); they are
+/// expanded only for probing. Displays and returns raw URLs so secrets are
+/// never shown on screen or written to config.
 pub async fn select_rpc(
     chain_name: &str,
     chain_id: u64,
-    available_rpcs: Vec<String>,
+    urls: Vec<String>,
     globals: &GlobalVariables,
 ) -> Result<String> {
-    println!("\nTesting RPCs...");
+    let expanded: Vec<String> = urls.iter().map(|u| globals.expand_rpc_url(u)).collect();
 
-    // Initialize displays with "testing" status
-    let mut rpc_displays: Vec<String> = available_rpcs
+    // Live per-RPC status lines; hidden automatically when not a TTY
+    let multi = MultiProgress::new();
+    let bars: Vec<ProgressBar> = urls
         .iter()
-        .map(|url| ui::dim(&format!("⋯ {}", url)))
+        .map(|url| {
+            let bar = multi.add(ProgressBar::new_spinner());
+            bar.set_style(ProgressStyle::with_template("{spinner} {msg}").unwrap());
+            bar.enable_steady_tick(std::time::Duration::from_millis(120));
+            bar.set_message(url.clone());
+            bar
+        })
         .collect();
 
-    // Test all RPCs concurrently against the expected chain id
-    let expanded: Vec<String> = available_rpcs
-        .iter()
-        .map(|url| globals.expand_rpc_url(url))
-        .collect();
-    for (idx, healthy) in check_urls(&expanded, chain_id)
-        .await
-        .into_iter()
-        .enumerate()
-    {
-        rpc_displays[idx] = if healthy {
-            ui::success(&available_rpcs[idx])
+    let mut results = Vec::with_capacity(urls.len());
+    let mut rx = probe_urls(&expanded, chain_id);
+    while let Some(result) = rx.recv().await {
+        let bar = &bars[result.index];
+        if result.healthy {
+            bar.finish_with_message(ui::success(&format!(
+                "{}  {}ms",
+                urls[result.index],
+                result.latency.as_millis()
+            )));
         } else {
-            ui::fail(&available_rpcs[idx])
-        };
+            bar.finish_with_message(ui::fail(&format!(
+                "{}  {}",
+                urls[result.index],
+                ui::dim("unreachable")
+            )));
+        }
+        results.push(result);
     }
 
-    // Add manual entry option
-    rpc_displays.push("Enter RPC URL manually...".to_string());
+    // Healthy-first, fastest-first picker over RAW urls
+    let order = rank_by_health(&results);
+    let mut items: Vec<String> = order
+        .iter()
+        .map(|&i| {
+            let r = results.iter().find(|r| r.index == i).unwrap();
+            if r.healthy {
+                format!("{} ({}ms)", urls[i], r.latency.as_millis())
+            } else {
+                format!("{} (unreachable)", urls[i])
+            }
+        })
+        .collect();
+    items.push("Enter RPC URL manually...".to_string());
 
-    let rpc_selection = fuzzy_select(
+    let selection = fuzzy_select(
         &format!("Select an RPC URL for {}", ui::emph(chain_name)),
-        &rpc_displays,
+        &items,
         0,
     )?;
 
-    if rpc_selection == rpc_displays.len() - 1 {
+    if selection == items.len() - 1 {
         select_manual_rpc(chain_id, globals).await
-    } else if let Some(rpc) = available_rpcs.get(rpc_selection) {
-        Ok(rpc.clone())
     } else {
-        anyhow::bail!("Selected RPC is not working")
+        Ok(urls[order[selection]].clone())
     }
 }
 

--- a/src/chain/wizard.rs
+++ b/src/chain/wizard.rs
@@ -433,7 +433,11 @@ fn suggest_short_name(name: &str) -> String {
 }
 
 // Helper function to handle fuzzy select with ESC cancellation
-fn fuzzy_select<T: ToString>(prompt: &str, items: &[T], default: usize) -> Result<usize> {
+fn fuzzy_select<T: ToString + std::fmt::Display>(
+    prompt: &str,
+    items: &[T],
+    default: usize,
+) -> Result<usize> {
     match FuzzySelect::new()
         .with_prompt(format!("{} (ESC to exit)", prompt))
         .items(items)

--- a/src/chain/wizard.rs
+++ b/src/chain/wizard.rs
@@ -2,6 +2,7 @@ use super::{
     ChainDefinition, DEFAULT_KEY_NAME, Rpc,
     rpc::{check_urls, resolve_rpc, resolve_rpcs, test_rpc},
 };
+use crate::ui;
 use crate::{
     chainlist::{ChainlistEntry, fetch_all_chains, fetch_chain_by_id},
     config::Chainz,
@@ -10,7 +11,7 @@ use crate::{
     variables::GlobalVariables,
 };
 use anyhow::Result;
-use colored::*;
+use console::style;
 use dialoguer::{FuzzySelect, Input};
 
 /// Helper function to handle text input with ESC cancellation
@@ -39,7 +40,7 @@ pub async fn manual_chain_entry(
     name: Option<String>,
     chain_id: Option<u64>,
 ) -> Result<ChainlistEntry> {
-    println!("\n{}", "Manual Chain Entry".bright_yellow().bold());
+    println!("\n{}", style("Manual Chain Entry").yellow().bold());
     let name = if let Some(n) = name {
         n
     } else {
@@ -69,16 +70,16 @@ pub async fn select_rpc(
     // Initialize displays with "testing" status
     let mut rpc_displays: Vec<String> = available_rpcs
         .iter()
-        .map(|rpc| format!("{} {}", "⋯".bright_yellow(), rpc))
+        .map(|rpc| ui::dim(&format!("⋯ {}", rpc)))
         .collect();
 
     // Test all RPCs concurrently against the expected chain id
     let urls: Vec<String> = available_rpcs.iter().map(|r| r.rpc_url.clone()).collect();
     for (idx, healthy) in check_urls(&urls, chain_id).await.into_iter().enumerate() {
         rpc_displays[idx] = if healthy {
-            format!("{} {}", "✓".bright_green(), available_rpcs[idx])
+            ui::success(&format!("{}", available_rpcs[idx]))
         } else {
-            format!("{} {}", "✗".bright_red(), available_rpcs[idx])
+            ui::fail(&format!("{}", available_rpcs[idx]))
         };
     }
 
@@ -86,7 +87,7 @@ pub async fn select_rpc(
     rpc_displays.push("Enter RPC URL manually...".to_string());
 
     let rpc_selection = fuzzy_select(
-        &format!("Select an RPC URL for {}", chain_name.yellow()),
+        &format!("Select an RPC URL for {}", ui::emph(chain_name)),
         &rpc_displays,
         0,
     )?;
@@ -107,11 +108,11 @@ async fn select_manual_rpc(chain_id: u64) -> Result<Rpc> {
         let rpc = resolve_rpc(&rpc_url, &GlobalVariables::default()).await?;
 
         if test_rpc(&rpc, chain_id).await.is_ok() {
-            println!("{} RPC working", "✓".bright_green());
+            println!("{}", ui::success("RPC working"));
             return Ok(rpc);
         }
 
-        println!("{} RPC failed. Try again? (ESC to exit)", "✗".bright_red());
+        println!("{}", ui::fail("RPC failed. Try again? (ESC to exit)"));
     }
 }
 
@@ -175,8 +176,7 @@ pub fn select_verifier() -> Result<(Option<String>, Option<String>)> {
 
 impl UpdateArgs {
     pub async fn handle(&self, chainz: &mut Chainz) -> Result<ChainDefinition> {
-        println!("\n{}", "Chain Update".bright_blue().bold());
-        println!("{}", "═".bright_black().repeat(50));
+        println!("{}", ui::header("Chain Update"));
 
         // Select chain to update
         let chains: Vec<String> = chainz
@@ -196,8 +196,7 @@ impl UpdateArgs {
         // Select what to update
         let options = vec!["RPC URL", "Key", "Verification"];
 
-        println!("\n{}", "Update Options".bright_blue().bold());
-        println!("{}", "═".bright_black().repeat(50));
+        println!("{}", ui::header("Update Options"));
         println!("Current configuration:");
         println!("{}", chain);
 
@@ -206,8 +205,7 @@ impl UpdateArgs {
         match selection {
             0 => {
                 // Update RPC URL
-                println!("\n{}", "RPC Configuration".bright_blue().bold());
-                println!("{}", "═".bright_black().repeat(50));
+                println!("{}", ui::header("RPC Configuration"));
 
                 // Try to get fresh RPC list from chainlist
                 let chainlist_entry = fetch_chain_by_id(chain.chain_id, self.refresh).await;
@@ -225,16 +223,14 @@ impl UpdateArgs {
             }
             1 => {
                 // Update key
-                println!("\n{}", "Key Configuration".bright_blue().bold());
-                println!("{}", "═".bright_black().repeat(50));
+                println!("{}", ui::header("Key Configuration"));
 
                 let new_key = select_key(chainz)?;
                 chain.key_name = new_key;
             }
             2 => {
                 // Update verification API key
-                println!("\n{}", "Verification Configuration".bright_blue().bold());
-                println!("{}", "═".bright_black().repeat(50));
+                println!("{}", ui::header("Verification Configuration"));
 
                 let (verification_url, verification_key) = select_verifier()?;
                 chain.verification_url = verification_url;
@@ -246,7 +242,7 @@ impl UpdateArgs {
         // Save changes
         chainz.add_chain(chain.clone())?;
         chainz.save().await?;
-        println!("\n{}", "Chain updated successfully".bright_green());
+        println!("\n{}", style("Chain updated successfully").green());
 
         Ok(chain)
     }
@@ -307,8 +303,7 @@ impl AddArgs {
     }
 
     async fn handle_interactive(&self, chainz: &mut Chainz) -> Result<ChainDefinition> {
-        println!("\n{}", "Chain Selection".bright_blue().bold());
-        println!("{}", "═".bright_black().repeat(50));
+        println!("{}", ui::header("Chain Selection"));
 
         let selected_chain = if self.name.is_some() || self.chain_id.is_some() {
             // Pre-fill from CLI args when partially provided
@@ -349,11 +344,10 @@ impl AddArgs {
             println!("Testing RPC...");
             let rpc = resolve_rpc(rpc_url, &chainz.config.globals).await?;
             test_rpc(&rpc, selected_chain.chain_id).await?;
-            println!("{} RPC working", "✓".bright_green());
+            println!("{}", ui::success("RPC working"));
             rpc_url.clone()
         } else {
-            println!("\n{}", "RPC Configuration".bright_blue().bold());
-            println!("{}", "═".bright_black().repeat(50));
+            println!("{}", ui::header("RPC Configuration"));
 
             select_rpc(
                 &selected_chain.name,
@@ -372,8 +366,7 @@ impl AddArgs {
             })?;
             key.clone()
         } else {
-            println!("\n{}", "Key Configuration".bright_blue().bold());
-            println!("{}", "═".bright_black().repeat(50));
+            println!("{}", ui::header("Key Configuration"));
             select_key(chainz)?
         };
 

--- a/src/chain/wizard.rs
+++ b/src/chain/wizard.rs
@@ -10,7 +10,7 @@ use crate::{
     opt::{AddArgs, UpdateArgs},
     variables::GlobalVariables,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use console::style;
 use dialoguer::{FuzzySelect, Input};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -77,7 +77,9 @@ pub async fn select_rpc(
         .iter()
         .map(|url| {
             let bar = multi.add(ProgressBar::new_spinner());
-            bar.set_style(ProgressStyle::with_template("{spinner} {msg}").unwrap());
+            bar.set_style(
+                ProgressStyle::with_template("{spinner} {msg}").expect("static template"),
+            );
             bar.enable_steady_tick(std::time::Duration::from_millis(120));
             bar.set_message(url.clone());
             bar
@@ -106,10 +108,15 @@ pub async fn select_rpc(
 
     // Healthy-first, fastest-first picker over RAW urls
     let order = rank_by_health(&results);
+    // Index results by url position once, rather than a linear scan per item.
+    let mut by_index: Vec<Option<&_>> = vec![None; urls.len()];
+    for r in &results {
+        by_index[r.index] = Some(r);
+    }
     let mut items: Vec<String> = order
         .iter()
         .map(|&i| {
-            let r = results.iter().find(|r| r.index == i).unwrap();
+            let r = by_index[i].expect("every url index has a probe result");
             if r.healthy {
                 format!("{} ({}ms)", urls[i], r.latency.as_millis())
             } else {
@@ -309,7 +316,9 @@ impl AddArgs {
         })?;
 
         // Test the RPC
-        check_url(&chainz.config.globals.expand_rpc_url(&rpc_url), chain_id).await?;
+        check_url(&chainz.config.globals.expand_rpc_url(&rpc_url), chain_id)
+            .await
+            .with_context(|| format!("RPC check failed for {}", rpc_url))?;
 
         let chain_def = ChainDefinition {
             name: name.clone(),
@@ -379,7 +388,8 @@ impl AddArgs {
                 &chainz.config.globals.expand_rpc_url(rpc_url),
                 selected_chain.chain_id,
             )
-            .await?;
+            .await
+            .with_context(|| format!("RPC check failed for {}", rpc_url))?;
             println!("{}", ui::success("RPC working"));
             rpc_url.clone()
         } else {
@@ -463,11 +473,7 @@ fn suggest_short_name(name: &str) -> String {
 }
 
 // Helper function to handle fuzzy select with ESC cancellation
-fn fuzzy_select<T: ToString + std::fmt::Display>(
-    prompt: &str,
-    items: &[T],
-    default: usize,
-) -> Result<usize> {
+fn fuzzy_select<T: std::fmt::Display>(prompt: &str, items: &[T], default: usize) -> Result<usize> {
     match FuzzySelect::new()
         .with_prompt(format!("{} (ESC to exit)", prompt))
         .items(items)

--- a/src/chain/wizard.rs
+++ b/src/chain/wizard.rs
@@ -1,6 +1,6 @@
 use super::{
-    ChainDefinition, DEFAULT_KEY_NAME, Rpc,
-    rpc::{check_urls, resolve_rpc, resolve_rpcs, test_rpc},
+    ChainDefinition, DEFAULT_KEY_NAME,
+    rpc::{check_url, check_urls},
 };
 use crate::ui;
 use crate::{
@@ -59,27 +59,37 @@ pub async fn manual_chain_entry(
     })
 }
 
-/// Helper function to select or enter RPC URL
+/// Helper function to select or enter RPC URL.
+/// `available_rpcs` are raw (unexpanded) URLs; they are only expanded for
+/// the health probe itself and stored/displayed raw.
 pub async fn select_rpc(
     chain_name: &str,
     chain_id: u64,
-    available_rpcs: Vec<Rpc>,
+    available_rpcs: Vec<String>,
+    globals: &GlobalVariables,
 ) -> Result<String> {
     println!("\nTesting RPCs...");
 
     // Initialize displays with "testing" status
     let mut rpc_displays: Vec<String> = available_rpcs
         .iter()
-        .map(|rpc| ui::dim(&format!("⋯ {}", rpc)))
+        .map(|url| ui::dim(&format!("⋯ {}", url)))
         .collect();
 
     // Test all RPCs concurrently against the expected chain id
-    let urls: Vec<String> = available_rpcs.iter().map(|r| r.rpc_url.clone()).collect();
-    for (idx, healthy) in check_urls(&urls, chain_id).await.into_iter().enumerate() {
+    let expanded: Vec<String> = available_rpcs
+        .iter()
+        .map(|url| globals.expand_rpc_url(url))
+        .collect();
+    for (idx, healthy) in check_urls(&expanded, chain_id)
+        .await
+        .into_iter()
+        .enumerate()
+    {
         rpc_displays[idx] = if healthy {
-            ui::success(&format!("{}", available_rpcs[idx]))
+            ui::success(&available_rpcs[idx])
         } else {
-            ui::fail(&format!("{}", available_rpcs[idx]))
+            ui::fail(&available_rpcs[idx])
         };
     }
 
@@ -93,23 +103,25 @@ pub async fn select_rpc(
     )?;
 
     if rpc_selection == rpc_displays.len() - 1 {
-        Ok(select_manual_rpc(chain_id).await?.rpc_url)
+        select_manual_rpc(chain_id, globals).await
     } else if let Some(rpc) = available_rpcs.get(rpc_selection) {
-        Ok(rpc.rpc_url.clone())
+        Ok(rpc.clone())
     } else {
         anyhow::bail!("Selected RPC is not working")
     }
 }
 
-async fn select_manual_rpc(chain_id: u64) -> Result<Rpc> {
+async fn select_manual_rpc(chain_id: u64, globals: &GlobalVariables) -> Result<String> {
     loop {
         let rpc_url: String = text_input("Enter RPC URL", None)?;
         println!("Testing RPC...");
-        let rpc = resolve_rpc(&rpc_url, &GlobalVariables::default()).await?;
 
-        if test_rpc(&rpc, chain_id).await.is_ok() {
+        if check_url(&globals.expand_rpc_url(&rpc_url), chain_id)
+            .await
+            .is_ok()
+        {
             println!("{}", ui::success("RPC working"));
-            return Ok(rpc);
+            return Ok(rpc_url);
         }
 
         println!("{}", ui::fail("RPC failed. Try again? (ESC to exit)"));
@@ -216,7 +228,8 @@ impl UpdateArgs {
                 let new_rpc = select_rpc(
                     &chain.name,
                     chain.chain_id,
-                    resolve_rpcs(available_rpcs, &chainz.config.globals).await?,
+                    available_rpcs,
+                    &chainz.config.globals,
                 )
                 .await?;
                 chain.selected_rpc = new_rpc;
@@ -275,8 +288,7 @@ impl AddArgs {
         })?;
 
         // Test the RPC
-        let rpc = resolve_rpc(&rpc_url, &chainz.config.globals).await?;
-        test_rpc(&rpc, chain_id).await?;
+        check_url(&chainz.config.globals.expand_rpc_url(&rpc_url), chain_id).await?;
 
         let chain_def = ChainDefinition {
             name: name.clone(),
@@ -342,8 +354,11 @@ impl AddArgs {
         let selected_rpc = if let Some(rpc_url) = &self.rpc_url {
             // Use provided RPC URL directly
             println!("Testing RPC...");
-            let rpc = resolve_rpc(rpc_url, &chainz.config.globals).await?;
-            test_rpc(&rpc, selected_chain.chain_id).await?;
+            check_url(
+                &chainz.config.globals.expand_rpc_url(rpc_url),
+                selected_chain.chain_id,
+            )
+            .await?;
             println!("{}", ui::success("RPC working"));
             rpc_url.clone()
         } else {
@@ -352,7 +367,8 @@ impl AddArgs {
             select_rpc(
                 &selected_chain.name,
                 selected_chain.chain_id,
-                resolve_rpcs(selected_chain.rpc.clone(), &chainz.config.globals).await?,
+                selected_chain.rpc.clone(),
+                &chainz.config.globals,
             )
             .await?
         };

--- a/src/chainlist.rs
+++ b/src/chainlist.rs
@@ -64,7 +64,7 @@ async fn fetch_from_network() -> Result<String> {
                 ProgressStyle::with_template(
                     "downloading chainlist {bytes}/{total_bytes} [{bar:30}] {eta}",
                 )
-                .unwrap(),
+                .expect("static template"),
             );
             bar
         }

--- a/src/chainlist.rs
+++ b/src/chainlist.rs
@@ -50,16 +50,38 @@ pub async fn fetch_all_chains(refresh: bool) -> Result<Vec<ChainlistEntry>> {
 }
 
 async fn fetch_from_network() -> Result<String> {
+    use indicatif::{ProgressBar, ProgressStyle};
+
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
         .build()?;
-    Ok(client
-        .get(CHAINLIST_URL)
-        .send()
-        .await?
-        .error_for_status()?
-        .text()
-        .await?)
+    let mut response = client.get(CHAINLIST_URL).send().await?.error_for_status()?;
+
+    let bar = match response.content_length() {
+        Some(len) => {
+            let bar = ProgressBar::new(len);
+            bar.set_style(
+                ProgressStyle::with_template(
+                    "downloading chainlist {bytes}/{total_bytes} [{bar:30}] {eta}",
+                )
+                .unwrap(),
+            );
+            bar
+        }
+        None => {
+            let bar = ProgressBar::new_spinner();
+            bar.set_message("downloading chainlist…");
+            bar
+        }
+    };
+
+    let mut body = Vec::with_capacity(response.content_length().unwrap_or(0) as usize);
+    while let Some(chunk) = response.chunk().await? {
+        body.extend_from_slice(&chunk);
+        bar.inc(chunk.len() as u64);
+    }
+    bar.finish_and_clear();
+    Ok(String::from_utf8(body)?)
 }
 
 fn cache_path() -> Option<PathBuf> {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,12 +5,7 @@
 //! RPC failover deliberately lives here rather than in `exec`, which stays
 //! network-free and fast.
 
-use crate::{
-    chain::rpc::{check_url, check_urls},
-    config::Chainz,
-    key::KeyType,
-    ui,
-};
+use crate::{chain::rpc::check_urls, config::Chainz, key::KeyType, ui};
 use anyhow::Result;
 use console::style;
 
@@ -115,31 +110,34 @@ async fn check_rpc_health(chainz: &Chainz, report: &mut Report) -> Vec<String> {
     let checks: Vec<_> = chains
         .iter()
         .map(|c| {
-            let url = chainz.config.globals.expand_rpc_url(&c.selected_rpc);
+            let expanded = chainz.config.globals.expand_rpc_url(&c.selected_rpc);
+            let raw = c.selected_rpc.clone();
             let chain_id = c.chain_id;
             let name = c.name.clone();
-            tokio::spawn(async move { (name, healthy(&url, chain_id).await, url) })
+            tokio::spawn(async move {
+                let (healthy, latency) = crate::chain::rpc::probe(&expanded, chain_id).await;
+                (name, healthy, raw, latency)
+            })
         })
         .collect();
 
     let mut failed = Vec::new();
     for handle in checks {
-        let Ok((name, is_healthy, url)) = handle.await else {
+        let Ok((name, is_healthy, raw_url, latency)) = handle.await else {
             continue;
         };
         if is_healthy {
-            println!("  {}", ui::success(&format!("{} ({})", name, url)));
+            println!(
+                "  {}",
+                ui::success(&format!("{} ({}) {}ms", name, raw_url, latency.as_millis()))
+            );
         } else {
             report.failures += 1;
-            println!("  {}", ui::fail(&format!("{} ({})", name, url)));
+            println!("  {}", ui::fail(&format!("{} ({})", name, raw_url)));
             failed.push(name);
         }
     }
     failed
-}
-
-async fn healthy(expanded_url: &str, chain_id: u64) -> bool {
-    check_url(expanded_url, chain_id).await.is_ok()
 }
 
 async fn fix_rpcs(chainz: &mut Chainz, failed: &[String], report: &mut Report) -> Result<()> {
@@ -166,7 +164,7 @@ async fn fix_rpcs(chainz: &mut Chainz, failed: &[String], report: &mut Report) -
                 chainz.set_selected_rpc(name, candidates[i].clone())?;
                 println!(
                     "  {}",
-                    ui::success(&format!("{}: switched to {}", name, expanded[i]))
+                    ui::success(&format!("{}: switched to {}", name, candidates[i]))
                 );
                 report.failures = report.failures.saturating_sub(1);
                 fixed_any = true;

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -69,7 +69,7 @@ fn check_keys(chainz: &Chainz, report: &mut Report) {
                 ))
             );
         } else {
-            println!("  {}", ui::success(&format!("{}", key)));
+            println!("  {}", ui::success(&key.to_string()));
         }
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -58,7 +58,7 @@ pub async fn run(chainz: &mut Chainz, fix: bool) -> Result<Report> {
 }
 
 fn check_keys(chainz: &Chainz, report: &mut Report) {
-    println!("{}", ui::header("Keys"));
+    println!("{}", ui::section("Keys"));
     let keys = chainz.list_keys();
     if keys.is_empty() {
         println!("  no keys configured");
@@ -80,7 +80,7 @@ fn check_keys(chainz: &Chainz, report: &mut Report) {
 }
 
 fn check_key_references(chainz: &Chainz, report: &mut Report) {
-    println!("{}", ui::header("Key references"));
+    println!("{}", ui::section("Key references"));
     let mut ok = true;
     for chain in chainz.list_chains() {
         if chainz.get_key(&chain.key_name).is_err() {
@@ -103,7 +103,7 @@ fn check_key_references(chainz: &Chainz, report: &mut Report) {
 /// Concurrently health-check every chain's selected RPC.
 /// Returns the names of chains whose RPC failed.
 async fn check_rpc_health(chainz: &Chainz, report: &mut Report) -> Vec<String> {
-    println!("{}", ui::header("RPC health"));
+    println!("{}", ui::section("RPC health"));
     let chains = chainz.list_chains();
     if chains.is_empty() {
         println!("  no chains configured");
@@ -143,7 +143,7 @@ async fn healthy(expanded_url: &str, chain_id: u64) -> bool {
 }
 
 async fn fix_rpcs(chainz: &mut Chainz, failed: &[String], report: &mut Report) -> Result<()> {
-    println!("{}", ui::header("Fixing RPCs"));
+    println!("{}", ui::section("Fixing RPCs"));
     let mut fixed_any = false;
     for name in failed {
         let chain = chainz.config.get_chain(name)?;

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -9,9 +9,10 @@ use crate::{
     chain::rpc::{check_url, check_urls},
     config::Chainz,
     key::KeyType,
+    ui,
 };
 use anyhow::Result;
-use colored::*;
+use console::style;
 
 pub struct Report {
     pub failures: usize,
@@ -34,14 +35,14 @@ pub async fn run(chainz: &mut Chainz, fix: bool) -> Result<Report> {
 
     println!();
     match (report.failures, report.warnings) {
-        (0, 0) => println!("{} no issues found", "✓".bright_green()),
+        (0, 0) => println!("{}", ui::success("no issues found")),
         (f, w) => {
             println!(
                 "{} {} failure(s), {} warning(s){}",
                 if f > 0 {
-                    "✗".bright_red().to_string()
+                    style("✗").red().to_string()
                 } else {
-                    "⚠".bright_yellow().to_string()
+                    style("⚠").yellow().to_string()
                 },
                 f,
                 w,
@@ -57,7 +58,7 @@ pub async fn run(chainz: &mut Chainz, fix: bool) -> Result<Report> {
 }
 
 fn check_keys(chainz: &Chainz, report: &mut Report) {
-    println!("\n{}", "Keys".bright_blue().bold());
+    println!("{}", ui::header("Keys"));
     let keys = chainz.list_keys();
     if keys.is_empty() {
         println!("  no keys configured");
@@ -66,43 +67,43 @@ fn check_keys(chainz: &Chainz, report: &mut Report) {
         if let KeyType::PrivateKey { .. } = key.kind {
             report.warnings += 1;
             println!(
-                "  {} '{}' is stored as a plaintext private key — consider re-adding it with --type encrypted or --type keyring",
-                "⚠".bright_yellow(),
-                name
+                "  {}",
+                ui::warn(&format!(
+                    "'{}' is stored as a plaintext private key — consider re-adding it with --type encrypted or --type keyring",
+                    name
+                ))
             );
         } else {
-            println!("  {} {}", "✓".bright_green(), key);
+            println!("  {}", ui::success(&format!("{}", key)));
         }
     }
 }
 
 fn check_key_references(chainz: &Chainz, report: &mut Report) {
-    println!("\n{}", "Key references".bright_blue().bold());
+    println!("{}", ui::header("Key references"));
     let mut ok = true;
     for chain in chainz.list_chains() {
         if chainz.get_key(&chain.key_name).is_err() {
             report.failures += 1;
             ok = false;
             println!(
-                "  {} chain '{}' references missing key '{}'",
-                "✗".bright_red(),
-                chain.name,
-                chain.key_name
+                "  {}",
+                ui::fail(&format!(
+                    "chain '{}' references missing key '{}'",
+                    chain.name, chain.key_name
+                ))
             );
         }
     }
     if ok {
-        println!(
-            "  {} all chains reference existing keys",
-            "✓".bright_green()
-        );
+        println!("  {}", ui::success("all chains reference existing keys"));
     }
 }
 
 /// Concurrently health-check every chain's selected RPC.
 /// Returns the names of chains whose RPC failed.
 async fn check_rpc_health(chainz: &Chainz, report: &mut Report) -> Vec<String> {
-    println!("\n{}", "RPC health".bright_blue().bold());
+    println!("{}", ui::header("RPC health"));
     let chains = chainz.list_chains();
     if chains.is_empty() {
         println!("  no chains configured");
@@ -127,10 +128,10 @@ async fn check_rpc_health(chainz: &Chainz, report: &mut Report) -> Vec<String> {
             continue;
         };
         if is_healthy {
-            println!("  {} {} ({})", "✓".bright_green(), name, url);
+            println!("  {}", ui::success(&format!("{} ({})", name, url)));
         } else {
             report.failures += 1;
-            println!("  {} {} ({})", "✗".bright_red(), name, url);
+            println!("  {}", ui::fail(&format!("{} ({})", name, url)));
             failed.push(name);
         }
     }
@@ -142,7 +143,7 @@ async fn healthy(expanded_url: &str, chain_id: u64) -> bool {
 }
 
 async fn fix_rpcs(chainz: &mut Chainz, failed: &[String], report: &mut Report) -> Result<()> {
-    println!("\n{}", "Fixing RPCs".bright_blue().bold());
+    println!("{}", ui::header("Fixing RPCs"));
     let mut fixed_any = false;
     for name in failed {
         let chain = chainz.config.get_chain(name)?;
@@ -164,19 +165,19 @@ async fn fix_rpcs(chainz: &mut Chainz, failed: &[String], report: &mut Report) -
             Some(i) => {
                 chainz.set_selected_rpc(name, candidates[i].clone())?;
                 println!(
-                    "  {} {}: switched to {}",
-                    "✓".bright_green(),
-                    name,
-                    expanded[i]
+                    "  {}",
+                    ui::success(&format!("{}: switched to {}", name, expanded[i]))
                 );
                 report.failures = report.failures.saturating_sub(1);
                 fixed_any = true;
             }
             None => println!(
-                "  {} {}: no healthy alternative among {} configured RPC(s)",
-                "✗".bright_red(),
-                name,
-                chain.rpc_urls.len()
+                "  {}",
+                ui::fail(&format!(
+                    "{}: no healthy alternative among {} configured RPC(s)",
+                    name,
+                    chain.rpc_urls.len()
+                ))
             ),
         }
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,11 +2,10 @@ use crate::{
     chain::DEFAULT_KEY_NAME,
     config::{Chainz, config_exists},
     key::{Key, KeyType},
-    opt,
+    opt, ui,
 };
 use alloy::signers::local::PrivateKeySigner;
 use anyhow::Result;
-use colored::Colorize;
 use dialoguer::{Confirm, Input};
 
 const INFURA_API_KEY_ENV_VAR: &str = "INFURA_API_KEY";
@@ -31,8 +30,7 @@ pub async fn handle_init() -> Result<()> {
 }
 
 async fn initialize_with_wizard() -> Result<Chainz> {
-    println!("\n{}", "Chainz Initialization".bright_blue().bold());
-    println!("{}", "═".bright_black().repeat(50));
+    println!("{}", ui::header("Chainz Initialization"));
     let mut chainz = Chainz::new();
 
     let private_key = {
@@ -67,8 +65,7 @@ async fn initialize_with_wizard() -> Result<Chainz> {
 
     // Add chains in a loop until user chooses to exit
     loop {
-        println!("\n{}", "Chain Management".bright_blue().bold());
-        println!("{}", "═".bright_black().repeat(50));
+        println!("{}", ui::header("Chain Management"));
         let should_add = Confirm::new()
             .with_prompt("Would you like to add another chain?")
             .default(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@ pub mod doctor;
 pub mod init;
 pub mod key;
 pub mod opt;
+pub mod ui;
 pub mod variables;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chainz::{config::Chainz, doctor, init, opt, opt::Opt, variables::ChainVariables};
+use chainz::{config::Chainz, doctor, init, opt, opt::Opt, ui, variables::ChainVariables};
 use clap::{CommandFactory, Parser};
 use dialoguer::FuzzySelect;
 use std::process::Command as ProcessCommand;
@@ -91,6 +91,36 @@ async fn main() -> Result<()> {
             let report = doctor::run(&mut chainz, fix).await?;
             if report.failures > 0 {
                 std::process::exit(1);
+            }
+        }
+        opt::Command::Shell { name_or_id } => {
+            let name_or_id = match name_or_id.or_else(|| chainz.config.default_chain.clone()) {
+                Some(id) => id,
+                None => select_chain(&chainz)?,
+            };
+            let chain = chainz.get_chain(&name_or_id)?;
+            // Empty command args → lazy rule: key backends are never touched
+            let variables = ChainVariables::new(&chain, &[])?;
+            let chain_name = chain.definition.name.clone();
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string());
+
+            eprintln!(
+                "{}",
+                ui::item(&format!("entering {} shell — ctrl-d to exit", chain_name))
+            );
+            let ps1 = format!(
+                "(⛓ {}) {}",
+                chain_name,
+                std::env::var("PS1").unwrap_or_default()
+            );
+            let status = ProcessCommand::new(&shell)
+                .envs(variables.as_map())
+                .env("CHAINZ_CHAIN", &chain_name)
+                .env("PS1", ps1)
+                .status()?;
+            eprintln!("{}", ui::dim(&format!("left {} shell", chain_name)));
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
             }
         }
         opt::Command::Exec {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -97,6 +97,18 @@ pub enum Command {
         key: Option<String>,
     },
 
+    /// Open a subshell with the chain's environment loaded
+    ///
+    /// Sets ETH_RPC_URL, CHAIN_ID, CHAIN_NAME, VERIFIER_* and CHAINZ_CHAIN,
+    /// and prefixes PS1 with the chain name for bash-like shells.
+    /// Key material is NOT loaded into the environment.
+    ///
+    /// Example: chainz shell base
+    Shell {
+        /// Chain name or ID (default chain or interactive picker if omitted)
+        name_or_id: Option<String>,
+    },
+
     /// Manage private keys
     ///
     /// Subcommands for adding, listing, and removing private keys.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 //! The single output vocabulary for chainz. Every user-facing styled line
 //! goes through these helpers so glyphs and palette stay coherent.
-//! `console` styles only when stderr/stdout is a TTY and honors NO_COLOR.
+//! `console` styles only when stdout is detected as a TTY, and honors NO_COLOR.
 
 use console::style;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,6 +12,11 @@ pub fn header(title: &str) -> String {
     )
 }
 
+/// A section title without header's separator rule.
+pub fn section(title: &str) -> String {
+    format!("\n{}", style(title).cyan().bold())
+}
+
 pub fn success(msg: &str) -> String {
     format!("{} {}", style("✓").green(), msg)
 }
@@ -49,5 +54,7 @@ mod tests {
         assert!(item("step").contains("▸"));
         assert!(header("Section").contains("Section"));
         assert!(header("Section").contains("═"));
+        assert!(section("Keys").contains("Keys"));
+        assert!(!section("Keys").contains("═"));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,53 @@
+//! The single output vocabulary for chainz. Every user-facing styled line
+//! goes through these helpers so glyphs and palette stay coherent.
+//! `console` styles only when stderr/stdout is a TTY and honors NO_COLOR.
+
+use console::style;
+
+pub fn header(title: &str) -> String {
+    format!(
+        "\n{}\n{}",
+        style(title).cyan().bold(),
+        style("═".repeat(50)).dim()
+    )
+}
+
+pub fn success(msg: &str) -> String {
+    format!("{} {}", style("✓").green(), msg)
+}
+
+pub fn warn(msg: &str) -> String {
+    format!("{} {}", style("⚠").yellow(), msg)
+}
+
+pub fn fail(msg: &str) -> String {
+    format!("{} {}", style("✗").red(), msg)
+}
+
+pub fn item(msg: &str) -> String {
+    format!("{} {}", style("▸").cyan(), msg)
+}
+
+pub fn dim(msg: &str) -> String {
+    style(msg).dim().to_string()
+}
+
+pub fn emph(msg: &str) -> String {
+    style(msg).yellow().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helpers_contain_glyph_and_message() {
+        assert!(success("done").contains("✓"));
+        assert!(success("done").contains("done"));
+        assert!(warn("careful").contains("⚠"));
+        assert!(fail("broken").contains("✗"));
+        assert!(item("step").contains("▸"));
+        assert!(header("Section").contains("Section"));
+        assert!(header("Section").contains("═"));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -591,6 +591,59 @@ fn legacy_config_location_is_migrated() {
 }
 
 #[test]
+fn shell_sets_env_and_passes_exit_code() {
+    let home = TempDir::new().unwrap();
+    seed_config(home.path(), &[("testchain", 31337)]);
+
+    // A fake "shell" that proves env vars arrive and exit codes pass through
+    let fake_shell = home.path().join("fakeshell.sh");
+    fs::write(
+        &fake_shell,
+        "#!/bin/sh\necho chain=$CHAINZ_CHAIN rpc=$ETH_RPC_URL key=${RAW_PRIVATE_KEY:-unset}\nexit 3\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_shell, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    chainz(home.path())
+        .env("SHELL", &fake_shell)
+        .args(["shell", "testchain"])
+        .assert()
+        .code(3)
+        .stdout(predicate::str::contains(
+            "chain=testchain rpc=http://localhost:1 key=unset",
+        ));
+}
+
+#[test]
+fn shell_uses_default_chain_when_omitted() {
+    let home = TempDir::new().unwrap();
+    seed_config(home.path(), &[("testchain", 31337)]);
+    chainz(home.path())
+        .args(["use", "testchain"])
+        .assert()
+        .success();
+
+    let fake_shell = home.path().join("fakeshell.sh");
+    fs::write(&fake_shell, "#!/bin/sh\necho in=$CHAINZ_CHAIN\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_shell, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    chainz(home.path())
+        .env("SHELL", &fake_shell)
+        .arg("shell")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("in=testchain"));
+}
+
+#[test]
 fn add_noninteractive_requires_existing_key() {
     let home = TempDir::new().unwrap();
     chainz(home.path())


### PR DESCRIPTION
## Summary

Phase 4 Part 2 (per `docs/superpowers/specs/2026-07-16-phase4-design.md`): the terminal-experience overhaul. Executed task-by-task via subagent-driven development with per-task spec+quality reviews and a final whole-branch review (verdict: ready to merge).

### One style system
- New `src/ui.rs` (console + indicatif) is the single output vocabulary; `colored` removed; dialoguer bumped to 0.12 so the whole stack shares console 0.16
- Non-TTY and `--json` output stay byte-identical (pinned by the integration suite)

### Streaming RPC probes (the "slow add wizard" fix)
- One probe definition: `probe`/`probe_urls` with a **4s deadline** (was 10s worst-case), latency measured; the old `Rpc`/`resolve_rpc`/`resolve_rpcs`/`test_rpc` surface is deleted
- `chainz add`/`update`: per-RPC statuses stream live (`✓ url 89ms` / `✗ unreachable`), picker opens immediately after, **healthy-first sorted by latency**
- `chainz doctor` shows latency per chain on the same shared probe
- **Raw-vs-expanded URL boundary**: pickers, doctor output, error contexts, and config storage always use raw `${VAR}` URLs — the old flow displayed expanded URLs on screen and baked API keys into `selected_rpc`

### chainz shell
- `chainz shell [chain]`: subshell with the chain env + `CHAINZ_CHAIN`, `(⛓ chain)` PS1 prefix where honored, starship snippet documented; **private keys are never injected**; exit-code passthrough; exec-style chain resolution

### Also
- Chainlist download progress bar (and stale-cache behavior unchanged)
- README updated to match

## Test plan
- 94 tests (63 unit + 31 integration, including new shell/probe coverage), `clippy -D warnings` clean, `fmt --check` clean
- Reviewers independently reproduced the TDD red states and full gate; starship snippet verified against the real starship binary
- ⚠️ One manual check remains for a human with a TTY: `cargo run -- add` (live spinners + ranked picker), `add --refresh` (download bar), and `chainz shell` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)